### PR TITLE
Support for the newer node.js API.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - "6.1"
-  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "6.1"
   - "0.10"
+  - "lts/*"

--- a/src/_wrapper_shared.js
+++ b/src/_wrapper_shared.js
@@ -156,7 +156,10 @@ function safeConnectionWrapper(fn, wrappingSafeConnect) {
   wrappingSafeConnect = (wrappingSafeConnect || false);
 
   return function safeConnectionWrappedFn() { // eslint-disable-line max-statements
-    const args = net._normalizeConnectArgs(arguments);
+
+    const normalizeArgs = net._normalizeArgs ? net._normalizeArgs : net._normalizeConnectArgs;
+
+    const args = normalizeArgs(arguments);
     const options = args[0];
 
     // We smuggled our validator through localAddress

--- a/src/http.js
+++ b/src/http.js
@@ -25,7 +25,10 @@ import wrapperShared from './_wrapper_shared';
 
 // Use our custom connection function that won't need a synchronous DNS lookup
 function safeConnectionFunc() {
-  const args = net._normalizeConnectArgs(arguments);
+
+  const normalizeArgs = net._normalizeArgs ? net._normalizeArgs : net._normalizeConnectArgs;
+  const args = normalizeArgs(arguments);
+
   const options = args[0];
   const s = new net.Socket(args[0]);
   const newOptions = util._extend({}, options);


### PR DESCRIPTION
Since node v7 the old `_normalizeConnectArgs` function no longer exists. This PR changes the 2 places where this function is used, and use the newer `_normalizeArgs` if it's available.

This fixes #3 