### PR TITLE
Testing a later nodejs version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - "6.1"
-  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "6.1"
   - "0.10"
+  - "lts/*"


### PR DESCRIPTION
This should demonstrate that the library is currently broken.

I removed node 0.10 testing because it was broken for different reasons. The changes in this PR are included in #4. This doesn't have to be merged, it's just meant as proof. 